### PR TITLE
Updated code to add to menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Example in `esx_policejob: client/main.lua`:
 		
 		
 		if data2.current.value == 'jail' then
-			JailPlayer(GetPlayerServerId(player))
+			JailPlayer(GetPlayerServerId(closestPlayer))
 		end
 
 ---


### PR DESCRIPTION
Changed the code that adds the jail option in the cop menu, so that it works with the latest esx_policejob version. Now cops can jail the player closest to them instead of the first person on the scoreboard.